### PR TITLE
Add footers with author names, create date and first commit hash ID

### DIFF
--- a/baleen.go
+++ b/baleen.go
@@ -2,5 +2,14 @@
 Package baleen is the top level library of the baleen language ingestion service. This
 library provides the primary components for running the service as a long running
 background daemon including the main service itself, configuration and other utilities.
+
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Thu Apr 25 18:32:19 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: baleen.go [68a2562] benjamin@bengfort.com $
 */
 package baleen

--- a/baleen.go
+++ b/baleen.go
@@ -2,7 +2,10 @@
 Package baleen is the top level library of the baleen language ingestion service. This
 library provides the primary components for running the service as a long running
 background daemon including the main service itself, configuration and other utilities.
+*/
+package baleen
 
+/*
 Author:  Benjamin Bengfort
 Author:  Rebecca Bilbro
 Created: Thu Apr 25 18:32:19 2019 -0400
@@ -12,4 +15,3 @@ For license information, see LICENSE.txt
 
 ID: baleen.go [68a2562] benjamin@bengfort.com $
 */
-package baleen

--- a/baleen_test.go
+++ b/baleen_test.go
@@ -1,14 +1,5 @@
 /*
 Package baleen_test provides testing for the functions in the baleen package.
-
-Author:  Benjamin Bengfort
-Author:  Rebecca Bilbro
-Created: Thu Apr 25 18:32:19 2019 -0400
-
-Copyright (C) 2019 Kansas Labs
-For license information, see LICENSE.txt
-
-ID: baleen_test.go [68a2562] benjamin@bengfort.com $
 */
 package baleen_test
 
@@ -50,3 +41,14 @@ func equals(tb testing.TB, exp, act interface{}) {
 		tb.FailNow()
 	}
 }
+
+/*
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Thu Apr 25 18:32:19 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: baleen_test.go [68a2562] benjamin@bengfort.com $
+*/

--- a/baleen_test.go
+++ b/baleen_test.go
@@ -1,3 +1,15 @@
+/*
+Package baleen_test provides testing for the functions in the baleen package.
+
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Thu Apr 25 18:32:19 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: baleen_test.go [68a2562] benjamin@bengfort.com $
+*/
 package baleen_test
 
 import (

--- a/cmd/baleen/main.go
+++ b/cmd/baleen/main.go
@@ -1,3 +1,16 @@
+/*
+Package main serves as the primary entry point for launching the Baleen
+command line application.
+
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Thu Apr 25 18:32:19 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: main.go [68a2562] benjamin@bengfort.com $
+*/
 package main
 
 import (

--- a/cmd/baleen/main.go
+++ b/cmd/baleen/main.go
@@ -1,15 +1,6 @@
 /*
 Package main serves as the primary entry point for launching the Baleen
 command line application.
-
-Author:  Benjamin Bengfort
-Author:  Rebecca Bilbro
-Created: Thu Apr 25 18:32:19 2019 -0400
-
-Copyright (C) 2019 Kansas Labs
-For license information, see LICENSE.txt
-
-ID: main.go [68a2562] benjamin@bengfort.com $
 */
 package main
 
@@ -77,3 +68,14 @@ func run(c *cli.Context) (err error) {
 
 	return nil
 }
+
+/*
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Thu Apr 25 18:32:19 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: main.go [68a2562] benjamin@bengfort.com $
+*/

--- a/fetch/error.go
+++ b/fetch/error.go
@@ -16,6 +16,7 @@ For more on RSS hacking and bandwidth minimization see:
 https://fishbowl.pastiche.org/2002/10/21/http_conditional_get_for_rss_hackers
 
 Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
 Created: Mon Apr 29 06:43:36 2019 -0400
 
 Copyright (C) 2019 Kansas Labs

--- a/fetch/error.go
+++ b/fetch/error.go
@@ -1,29 +1,3 @@
-/*
-Package fetch provides a high-level interface for going out to get RSS and Atom feeds
-from any source. Right now http and https requests are supported but future
-implementations may also include authenticated fetchers, etc. Fetchers are intended to
-synchronously make a single request to get the latest version the feed and to preserve
-the state of the last request to the feed they are managing. They ensure that
-connections are closed after each request use etag and last-modified headers to minimize
-the amount of bandwidth required.
-
-Basic Usage:
-
-	fetcher := fetch.New("https://www.example.com/rss")
-	feed, err := fetcher.Fetch()
-
-For more on RSS hacking and bandwidth minimization see:
-https://fishbowl.pastiche.org/2002/10/21/http_conditional_get_for_rss_hackers
-
-Author:  Benjamin Bengfort
-Author:  Rebecca Bilbro
-Created: Mon Apr 29 06:43:36 2019 -0400
-
-Copyright (C) 2019 Kansas Labs
-For license information, see LICENSE.txt
-
-ID: error.go [d6dba70] benjamin@bengfort.com $
-*/
 package fetch
 
 import (
@@ -54,3 +28,14 @@ func (e HTTPError) NotModified() bool {
 func (e HTTPError) NotFound() bool {
 	return e.Code == http.StatusNotFound
 }
+
+/*
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Mon Apr 29 06:43:36 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: error.go [d6dba70] benjamin@bengfort.com $
+*/

--- a/fetch/error.go
+++ b/fetch/error.go
@@ -1,3 +1,28 @@
+/*
+Package fetch provides a high-level interface for going out to get RSS and Atom feeds
+from any source. Right now http and https requests are supported but future
+implementations may also include authenticated fetchers, etc. Fetchers are intended to
+synchronously make a single request to get the latest version the feed and to preserve
+the state of the last request to the feed they are managing. They ensure that
+connections are closed after each request use etag and last-modified headers to minimize
+the amount of bandwidth required.
+
+Basic Usage:
+
+	fetcher := fetch.New("https://www.example.com/rss")
+	feed, err := fetcher.Fetch()
+
+For more on RSS hacking and bandwidth minimization see:
+https://fishbowl.pastiche.org/2002/10/21/http_conditional_get_for_rss_hackers
+
+Author:  Benjamin Bengfort
+Created: Mon Apr 29 06:43:36 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: error.go [d6dba70] benjamin@bengfort.com $
+*/
 package fetch
 
 import (

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -14,15 +14,6 @@ Basic Usage:
 
 For more on RSS hacking and bandwidth minimization see:
 https://fishbowl.pastiche.org/2002/10/21/http_conditional_get_for_rss_hackers
-
-Author:  Benjamin Bengfort
-Author:  Rebecca Bilbro
-Created: Mon Apr 29 06:43:36 2019 -0400
-
-Copyright (C) 2019 Kansas Labs
-For license information, see LICENSE.txt
-
-ID: fetch.go [d6dba70] benjamin@bengfort.com $
 */
 package fetch
 
@@ -176,3 +167,14 @@ func (f *httpFetcher) newRequest() (req *http.Request, err error) {
 
 	return req, nil
 }
+
+/*
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Mon Apr 29 06:43:36 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: fetch.go [d6dba70] benjamin@bengfort.com $
+*/

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -14,6 +14,15 @@ Basic Usage:
 
 For more on RSS hacking and bandwidth minimization see:
 https://fishbowl.pastiche.org/2002/10/21/http_conditional_get_for_rss_hackers
+
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Mon Apr 29 06:43:36 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: fetch.go [d6dba70] benjamin@bengfort.com $
 */
 package fetch
 

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -1,14 +1,5 @@
 /*
 Package fetch_test provides testing for the functions in the fetch package.
-
-Author:  Benjamin Bengfort
-Author:  Rebecca Bilbro
-Created: Mon Apr 29 06:43:36 2019 -0400
-
-Copyright (C) 2019 Kansas Labs
-For license information, see LICENSE.txt
-
-ID: fetch_test.go [d6dba70] benjamin@bengfort.com $
 */
 package fetch_test
 
@@ -153,3 +144,14 @@ func TestSendLastModified(t *testing.T) {
 	equals(t, he.Code, http.StatusNotModified)
 	assert(t, feed == nil, "feed is not nil")
 }
+
+/*
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Mon Apr 29 06:43:36 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: fetch_test.go [d6dba70] benjamin@bengfort.com $
+*/

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -1,3 +1,15 @@
+/*
+Package fetch_test provides testing for the functions in the fetch package.
+
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Mon Apr 29 06:43:36 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: fetch_test.go [d6dba70] benjamin@bengfort.com $
+*/
 package fetch_test
 
 import (

--- a/fetch/stf_test.go
+++ b/fetch/stf_test.go
@@ -1,3 +1,15 @@
+/*
+Package fetch_test provides testing for the functions in the fetch package.
+
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Mon Apr 29 06:43:36 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: stf_test.go [d6dba70] benjamin@bengfort.com $
+*/
 package fetch_test
 
 import (

--- a/fetch/stf_test.go
+++ b/fetch/stf_test.go
@@ -1,15 +1,3 @@
-/*
-Package fetch_test provides testing for the functions in the fetch package.
-
-Author:  Benjamin Bengfort
-Author:  Rebecca Bilbro
-Created: Mon Apr 29 06:43:36 2019 -0400
-
-Copyright (C) 2019 Kansas Labs
-For license information, see LICENSE.txt
-
-ID: stf_test.go [d6dba70] benjamin@bengfort.com $
-*/
 package fetch_test
 
 import (
@@ -50,3 +38,14 @@ func equals(tb testing.TB, exp, act interface{}) {
 		tb.FailNow()
 	}
 }
+
+/*
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Mon Apr 29 06:43:36 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: stf_test.go [d6dba70] benjamin@bengfort.com $
+*/

--- a/utils/opml.go
+++ b/utils/opml.go
@@ -33,3 +33,14 @@ type Outline struct {
 	HTMLURL string `xml:"htmlUrl,attr"`
 	Favicon string `xml:"rssfr-favicon,attr"`
 }
+
+/*
+Author:  Rebecca Bilbro
+Author:  Benjamin Bengfort
+Created: Tue Oct 8 13:47:54 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: opml.go [c23ae33] rebeccabilbro@users.noreply.github.com $
+*/

--- a/version.go
+++ b/version.go
@@ -2,16 +2,8 @@
 Package baleen is the top level library of the baleen language ingestion service. This
 library provides the primary components for running the service as a long running
 background daemon including the main service itself, configuration and other utilities.
-
-Author:  Benjamin Bengfort
-Author:  Rebecca Bilbro
-Created: Thu Apr 25 18:32:19 2019 -0400
-
-Copyright (C) 2019 Kansas Labs
-For license information, see LICENSE.txt
-
-ID: version.go [68a2562] benjamin@bengfort.com $
 */
+
 package baleen
 
 import "fmt"
@@ -42,3 +34,14 @@ func Version(short bool) string {
 	}
 	return vers
 }
+
+/*
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Thu Apr 25 18:32:19 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: version.go [68a2562] benjamin@bengfort.com $
+*/

--- a/version.go
+++ b/version.go
@@ -1,3 +1,17 @@
+/*
+Package baleen is the top level library of the baleen language ingestion service. This
+library provides the primary components for running the service as a long running
+background daemon including the main service itself, configuration and other utilities.
+
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Thu Apr 25 18:32:19 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: version.go [68a2562] benjamin@bengfort.com $
+*/
 package baleen
 
 import "fmt"

--- a/version_test.go
+++ b/version_test.go
@@ -1,3 +1,15 @@
+/*
+Package baleen_test provides testing for the functions in the baleen package.
+
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Thu Apr 25 18:32:19 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: version_test.go [68a2562] benjamin@bengfort.com $
+*/
 package baleen_test
 
 import (

--- a/version_test.go
+++ b/version_test.go
@@ -1,14 +1,5 @@
 /*
 Package baleen_test provides testing for the functions in the baleen package.
-
-Author:  Benjamin Bengfort
-Author:  Rebecca Bilbro
-Created: Thu Apr 25 18:32:19 2019 -0400
-
-Copyright (C) 2019 Kansas Labs
-For license information, see LICENSE.txt
-
-ID: version_test.go [68a2562] benjamin@bengfort.com $
 */
 package baleen_test
 
@@ -23,3 +14,14 @@ const expectedVersion = "0.0"
 func TestVersion(t *testing.T) {
 	equals(t, expectedVersion, Version(false))
 }
+
+/*
+Author:  Benjamin Bengfort
+Author:  Rebecca Bilbro
+Created: Thu Apr 25 18:32:19 2019 -0400
+
+Copyright (C) 2019 Kansas Labs
+For license information, see LICENSE.txt
+
+ID: version_test.go [68a2562] benjamin@bengfort.com $
+*/


### PR DESCRIPTION
This PR adds headers with author names, create date and first commit hash ID. The script scans a local directory for git repository metadata, and if files are found that have headers with and ID line stub, adds the correct initial commit hash to the ID line. Files in `vendor` and those without the .go file extension are ignored. Moving forward, this will require us to add the following header to all new Go files:

```go
/*
Package example is an example package.

Author:  Ykceb Orblib <ykceb@kansaslabs.com>
Created: Sat Sep 14 13:26:53 EDT 2019

Copyright (C) 2019 Kansas Labs
For license information, see LICENSE.txt

ID: example.go [] ykceb@orblib.com $ 
*/
```

V1 of the ID script for Kansas Golang packages can be found in [this gist](https://gist.github.com/rebeccabilbro/ca826de48434398921dfd951eeeeb770).