### PR TITLE
Add initial feeds for spanish, korean, greek, and multilingual

### DIFF
--- a/cmd/baleen/main.go
+++ b/cmd/baleen/main.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"encoding/xml"
 	"fmt"
+	"io/ioutil"
 	"os"
+
+	"path/filepath"
 
 	"github.com/kansaslabs/baleen"
 	"github.com/kansaslabs/baleen/fetch"
+	"github.com/kansaslabs/baleen/utils"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -31,35 +36,71 @@ func main() {
 }
 
 func run(c *cli.Context) (err error) {
-	if c.NArg() == 0 {
-		return cli.NewExitError("specify a feed to fetch", 1)
-	}
+	var root = filepath.Join("fixtures")
+	var files []string
+	var urls []string
 
-	url := c.Args()[0]
-	fetcher := fetch.New(url)
-	feed, err := fetcher.Fetch()
-
-	if err != nil {
-		switch he := err.(type) {
-		case fetch.HTTPError:
-			if he.NotFound() {
-				fmt.Println("the url you supplied was not valid")
+	// If the user specifies a feed via the command line, only get that one
+	if c.NArg() > 0 {
+		urls = append(urls, c.Args()[0])
+	} else {
+		// Otherwise retrieve feeds from files in the fixtures directory
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			files = append(files, path)
+			return nil
+		})
+		if err != nil {
+			panic(err)
+		}
+		for _, file := range files {
+			switch filepath.Ext(file) {
+			case ".opml":
+				o := utils.OPML{}
+				content, _ := ioutil.ReadFile(file)
+				err := xml.Unmarshal(content, &o)
+				if err != nil {
+					panic(err)
+				}
+				for _, outline := range o.Body.Outlines {
+					urls = append(urls, outline.XMLURL)
+				}
+			case ".json":
+				fmt.Println("parsing from json not yet implemented")
 			}
-			if he.NotModified() {
-				fmt.Println("no new items in the feed!")
-			}
-			return cli.NewExitError(err, 1)
-		default:
-			return cli.NewExitError(err, 1)
 		}
 	}
 
-	fmt.Println(feed.Title)
-	fmt.Println(feed.Description + "\n")
+	// Return an error is no feed was specified in the cli and none were retrieved from fixtures
+	if len(urls) == 0 {
+		return cli.NewExitError("specify a feed to fetch or add feeds to fixtures directory", 1)
+	}
 
-	for _, item := range feed.Items {
-		fmt.Println(item.Title)
-		fmt.Println(item.Description + "\n")
+	for _, url := range urls {
+		fetcher := fetch.New(url)
+		feed, err := fetcher.Fetch()
+
+		if err != nil {
+			switch he := err.(type) {
+			case fetch.HTTPError:
+				if he.NotFound() {
+					fmt.Println("the url you supplied was not valid")
+				}
+				if he.NotModified() {
+					fmt.Println("no new items in the feed!")
+				}
+				return cli.NewExitError(err, 1)
+			default:
+				return cli.NewExitError(err, 1)
+			}
+		}
+
+		fmt.Println(feed.Title)
+		fmt.Println(feed.Description + "\n")
+
+		for _, item := range feed.Items {
+			fmt.Println(item.Title)
+			fmt.Println(item.Description + "\n")
+		}
 	}
 
 	return nil

--- a/fixtures/feedly.json
+++ b/fixtures/feedly.json
@@ -1,0 +1,345 @@
+{
+    "opml": {
+        "head": {
+            "title": "Kansas subscriptions in feedly Cloud"
+        },
+        "body": {
+            "outline": [
+                {
+                    "outline": [
+                        {
+                            "outline": [
+                                {
+                                    "_type": "rss",
+                                    "_text": "ekathimerini.com",
+                                    "_title": "ekathimerini.com",
+                                    "_xmlUrl": "http://www.ekathimerini.com/rss",
+                                    "_htmlUrl": "http://www.ekathimerini.com/"
+                                },
+                                {
+                                    "_type": "rss",
+                                    "_text": "Η ΚΑΘΗΜΕΡΙΝΗ | Ημερήσια Πολιτική και Οικονομική Εφημερίδα",
+                                    "_title": "Η ΚΑΘΗΜΕΡΙΝΗ | Ημερήσια Πολιτική και Οικονομική Εφημερίδα",
+                                    "_xmlUrl": "http://www.kathimerini.gr/rss",
+                                    "_htmlUrl": "https://www.kathimerini.gr/"
+                                }
+                            ],
+                            "_text": "kathimerini",
+                            "_title": "kathimerini"
+                        },
+                        {
+                            "outline": [
+                                {
+                                    "_type": "rss",
+                                    "_text": "ert.gr",
+                                    "_title": "ert.gr",
+                                    "_xmlUrl": "https://www.ert.gr/feed/",
+                                    "_htmlUrl": "https://www.ert.gr"
+                                },
+                                {
+                                    "_type": "rss",
+                                    "_text": "ERT International",
+                                    "_title": "ERT International",
+                                    "_xmlUrl": "https://int.ert.gr/feed/",
+                                    "_htmlUrl": "https://int.ert.gr"
+                                }
+                            ],
+                            "_text": "ert",
+                            "_title": "ert"
+                        },
+                        {
+                            "outline": [
+                                {
+                                    "_type": "rss",
+                                    "_text": "The National Herald",
+                                    "_title": "The National Herald",
+                                    "_xmlUrl": "https://www.thenationalherald.com/feed/",
+                                    "_htmlUrl": "https://www.thenationalherald.com"
+                                },
+                                {
+                                    "_type": "rss",
+                                    "_text": "The National Herald GR",
+                                    "_title": "The National Herald GR",
+                                    "_xmlUrl": "https://www.ekirikas.com/feed/",
+                                    "_htmlUrl": "https://www.ekirikas.com"
+                                }
+                            ],
+                            "_text": "ekirikas",
+                            "_title": "ekirikas"
+                        }
+                    ],
+                    "_text": "greek-english",
+                    "_title": "greek-english"
+                },
+                {
+                    "outline": [
+                        {
+                            "outline": [
+                                {
+                                    "_type": "rss",
+                                    "_text": "조선닷컴 : 전체기사",
+                                    "_title": "조선닷컴 : 전체기사",
+                                    "_xmlUrl": "http://www.chosun.com/site/data/rss/rss.xml",
+                                    "_htmlUrl": "http://www.chosun.com"
+                                },
+                                {
+                                    "_type": "rss",
+                                    "_text": "The Chosun Ilbo",
+                                    "_title": "The Chosun Ilbo",
+                                    "_xmlUrl": "http://english.chosun.com/site/data/rss/rss.xml",
+                                    "_htmlUrl": "http://english.chosun.com"
+                                }
+                            ],
+                            "_text": "chosun",
+                            "_title": "chosun"
+                        },
+                        {
+                            "outline": [
+                                {
+                                    "_type": "rss",
+                                    "_text": "한국일보 주요기사",
+                                    "_title": "한국일보 주요기사",
+                                    "_xmlUrl": "http://rss.hankookilbo.com/rss_xml/main/mainpan.xml",
+                                    "_htmlUrl": "http://www.hankookilbo.com/"
+                                },
+                                {
+                                    "_type": "rss",
+                                    "_text": "Korea Times News",
+                                    "_title": "Korea Times News",
+                                    "_xmlUrl": "http://www.ktimes.com/www/rss/rss.xml",
+                                    "_htmlUrl": "http://www.koreatimes.co.kr/"
+                                }
+                            ],
+                            "_text": "hankook",
+                            "_title": "hankook"
+                        },
+                        {
+                            "outline": [
+                                {
+                                    "_type": "rss",
+                                    "_text": "전체기사 : 뉴스 : 한겨레 뉴스 - 인터넷한겨레",
+                                    "_title": "전체기사 : 뉴스 : 한겨레 뉴스 - 인터넷한겨레",
+                                    "_xmlUrl": "http://www.hani.co.kr/rss/",
+                                    "_htmlUrl": "http://www.hani.co.kr/arti/"
+                                },
+                                {
+                                    "_type": "rss",
+                                    "_text": "English Edition : The hankyoreh",
+                                    "_title": "English Edition : The hankyoreh",
+                                    "_xmlUrl": "http://english.hani.co.kr/rss/english_edition/",
+                                    "_htmlUrl": "http://english.hani.co.kr"
+                                }
+                            ],
+                            "_text": "hankyoreh",
+                            "_title": "hankyoreh"
+                        }
+                    ],
+                    "_text": "korean-english",
+                    "_title": "korean-english"
+                },
+                {
+                    "outline": [
+                        {
+                            "outline": [
+                                {
+                                    "_type": "rss",
+                                    "_text": "Granma - Órgano oficial del Partido Comunista de Cuba",
+                                    "_title": "Granma - Órgano oficial del Partido Comunista de Cuba",
+                                    "_xmlUrl": "http://www.granma.cu/feed",
+                                    "_htmlUrl": "http://www.granma.cu"
+                                },
+                                {
+                                    "_type": "rss",
+                                    "_text": "Granma - Órgano oficial del Partido Comunista de Cuba",
+                                    "_title": "Granma - Órgano oficial del Partido Comunista de Cuba",
+                                    "_xmlUrl": "http://en.granma.cu/feed",
+                                    "_htmlUrl": "http://en.granma.cu"
+                                }
+                            ],
+                            "_text": "granma",
+                            "_title": "granma"
+                        },
+                        {
+                            "outline": [
+                                {
+                                    "_type": "rss",
+                                    "_text": "Agencia EFE | www.efe.com | Edición España",
+                                    "_title": "Agencia EFE | www.efe.com | Edición España",
+                                    "_xmlUrl": "http://www.efe.com/efe/noticias/espana/1/rss",
+                                    "_htmlUrl": "https://www.efe.com/efe/espana/1/rss"
+                                },
+                                {
+                                    "_type": "rss",
+                                    "_text": "Agencia EFE | www.efe.com | English edition",
+                                    "_title": "Agencia EFE | www.efe.com | English edition",
+                                    "_xmlUrl": "http://www.efe.com/efe/noticias/english/4/rss",
+                                    "_htmlUrl": "https://www.efe.com/efe/english/4/rss"
+                                }
+                            ],
+                            "_text": "efe",
+                            "_title": "efe"
+                        },
+                        {
+                            "outline": [
+                                {
+                                    "_type": "rss",
+                                    "_text": "In English Section | EL PAÍS",
+                                    "_title": "In English Section | EL PAÍS",
+                                    "_xmlUrl": "http://ep01.epimg.net/rss/elpais/inenglish.xml",
+                                    "_htmlUrl": "https://elpais.com/rss/elpais/inenglish.xml"
+                                },
+                                {
+                                    "_type": "rss",
+                                    "_text": "Portada de EL PAÍS",
+                                    "_title": "Portada de EL PAÍS",
+                                    "_xmlUrl": "http://www.elpais.com/rss/feed.html?feedId=1022",
+                                    "_htmlUrl": "https://elpais.com/rss/elpais/portada.xml"
+                                }
+                            ],
+                            "_text": "elpais",
+                            "_title": "elpais"
+                        },
+                        {
+                            "outline": [
+                                {
+                                    "_type": "rss",
+                                    "_text": "GARA Euskal Herriko egunkaria | naiz.eus",
+                                    "_title": "GARA Euskal Herriko egunkaria | naiz.eus",
+                                    "_xmlUrl": "https://www.naiz.eus/es/rss/publications/gara.rss",
+                                    "_htmlUrl": "https://www.naiz.eus/es/rss/publications/gara.rss"
+                                },
+                                {
+                                    "_type": "rss",
+                                    "_text": "GARA Euskal Herriko egunkaria | naiz.eus | English",
+                                    "_title": "GARA Euskal Herriko egunkaria | naiz.eus | English",
+                                    "_xmlUrl": "https://www.naiz.eus/en/rss/publications/gara.rss",
+                                    "_htmlUrl": "https://www.naiz.eus/en/rss/publications/gara.rss"
+                                }
+                            ],
+                            "_text": "gara",
+                            "_title": "gara"
+                        }
+                    ],
+                    "_text": "spanish-english",
+                    "_title": "spanish-english"
+                },
+                {
+                    "outline": {
+                        "outline": [
+                            {
+                                "_type": "rss",
+                                "_text": "BBC News 코리아 - 홈페이지",
+                                "_title": "BBC News 코리아 - 홈페이지",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/korean/rss.xml",
+                                "_htmlUrl": "https://www.bbckorean.com"
+                            },
+                            {
+                                "_type": "rss",
+                                "_text": "BBC News - World",
+                                "_title": "BBC News - World",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/news/world/rss.xml",
+                                "_htmlUrl": "https://www.bbc.co.uk/news/"
+                            },
+                            {
+                                "_type": "rss",
+                                "_text": "BBC Uzbek - Бош саҳифа",
+                                "_title": "BBC Uzbek - Бош саҳифа",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/uzbek/rss.xml",
+                                "_htmlUrl": "http://www.bbcuzbek.com"
+                            },
+                            {
+                                "_type": "rss",
+                                "_text": "BBC News Україна - Новини",
+                                "_title": "BBC News Україна - Новини",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/ukrainian/rss.xml",
+                                "_htmlUrl": "http://www.bbcukrainian.com"
+                            },
+                            {
+                                "_type": "rss",
+                                "_text": "BBC News Indonesia - Berita",
+                                "_title": "BBC News Indonesia - Berita",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/indonesia/rss.xml",
+                                "_htmlUrl": "http://www.bbcindonesia.com"
+                            },
+                            {
+                                "_type": "rss",
+                                "_text": "BBC Mundo - Noticias",
+                                "_title": "BBC Mundo - Noticias",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/mundo/rss.xml",
+                                "_htmlUrl": "http://www.bbcmundo.com"
+                            },
+                            {
+                                "_type": "rss",
+                                "_text": "BBC News اردو - خبریں، تازہ خبریں، بریکنگ نیو | News, latest news, breaking news",
+                                "_title": "BBC News اردو - خبریں، تازہ خبریں، بریکنگ نیو | News, latest news, breaking news",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/urdu/rss.xml",
+                                "_htmlUrl": "http://www.bbcurdu.com"
+                            },
+                            {
+                                "_type": "rss",
+                                "_text": "BBC Russian - Главная",
+                                "_title": "BBC Russian - Главная",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/russian/rss.xml",
+                                "_htmlUrl": "http://www.bbcrussian.com"
+                            },
+                            {
+                                "_type": "rss",
+                                "_text": "BBC News தமிழ் - முகப்பு",
+                                "_title": "BBC News தமிழ் - முகப்பு",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/tamil/rss.xml",
+                                "_htmlUrl": "http://www.bbctamil.com"
+                            },
+                            {
+                                "_type": "rss",
+                                "_text": "BBC News Tiếng Việt - Tin chính",
+                                "_title": "BBC News Tiếng Việt - Tin chính",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/vietnamese/rss.xml",
+                                "_htmlUrl": "http://www.bbcvietnamese.com"
+                            },
+                            {
+                                "_type": "rss",
+                                "_text": "BBC News नेपाल - समाचार, भर्खरै प्राप्त समाचार, भिडिओ, विश्लेषण, प्रतिक्रिया | बीबीसी नेपाली",
+                                "_title": "BBC News नेपाल - समाचार, भर्खरै प्राप्त समाचार, भिडिओ, विश्लेषण, प्रतिक्रिया | बीबीसी नेपाली",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/nepali/rss.xml",
+                                "_htmlUrl": "http://www.bbcnepali.com"
+                            },
+                            {
+                                "_type": "rss",
+                                "_text": "BBC Brasil - Notícias, vídeos, análise e contexto em português",
+                                "_title": "BBC Brasil - Notícias, vídeos, análise e contexto em português",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/portuguese/rss.xml",
+                                "_htmlUrl": "http://www.bbcbrasil.com"
+                            },
+                            {
+                                "_type": "rss",
+                                "_text": "BBC Turkish - Haberler, Son Dakika Haberleri, Haber-Analiz, Video",
+                                "_title": "BBC Turkish - Haberler, Son Dakika Haberleri, Haber-Analiz, Video",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/turkce/rss.xml",
+                                "_htmlUrl": "http://www.bbcturkce.com"
+                            },
+                            {
+                                "_type": "rss",
+                                "_text": "BBC Cymru Fyw - Newyddion a mwy",
+                                "_title": "BBC Cymru Fyw - Newyddion a mwy",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/cymrufyw/rss.xml",
+                                "_htmlUrl": "http://www.bbc.co.uk/cymrufyw"
+                            },
+                            {
+                                "_type": "rss",
+                                "_text": "BBC Chinese - 主页",
+                                "_title": "BBC Chinese - 主页",
+                                "_xmlUrl": "http://feeds.bbci.co.uk/zhongwen/simp/rss.xml",
+                                "_htmlUrl": "http://www.bbcchinese.com"
+                            }
+                        ],
+                        "_text": "bbc",
+                        "_title": "bbc"
+                    },
+                    "_text": "multilingual",
+                    "_title": "multilingual"
+                }
+            ]
+        },
+        "_version": "1.0"
+    }
+}

--- a/fixtures/feedly.json
+++ b/fixtures/feedly.json
@@ -6,337 +6,249 @@
         "body": {
             "outline": [
                 {
-                    "outline": [
-                        {
-                            "outline": [
-                                {
-                                    "_type": "rss",
-                                    "_text": "ekathimerini.com",
-                                    "_title": "ekathimerini.com",
-                                    "_xmlUrl": "http://www.ekathimerini.com/rss",
-                                    "_htmlUrl": "http://www.ekathimerini.com/"
-                                },
-                                {
-                                    "_type": "rss",
-                                    "_text": "Η ΚΑΘΗΜΕΡΙΝΗ | Ημερήσια Πολιτική και Οικονομική Εφημερίδα",
-                                    "_title": "Η ΚΑΘΗΜΕΡΙΝΗ | Ημερήσια Πολιτική και Οικονομική Εφημερίδα",
-                                    "_xmlUrl": "http://www.kathimerini.gr/rss",
-                                    "_htmlUrl": "https://www.kathimerini.gr/"
-                                }
-                            ],
-                            "_text": "kathimerini",
-                            "_title": "kathimerini"
-                        },
-                        {
-                            "outline": [
-                                {
-                                    "_type": "rss",
-                                    "_text": "ert.gr",
-                                    "_title": "ert.gr",
-                                    "_xmlUrl": "https://www.ert.gr/feed/",
-                                    "_htmlUrl": "https://www.ert.gr"
-                                },
-                                {
-                                    "_type": "rss",
-                                    "_text": "ERT International",
-                                    "_title": "ERT International",
-                                    "_xmlUrl": "https://int.ert.gr/feed/",
-                                    "_htmlUrl": "https://int.ert.gr"
-                                }
-                            ],
-                            "_text": "ert",
-                            "_title": "ert"
-                        },
-                        {
-                            "outline": [
-                                {
-                                    "_type": "rss",
-                                    "_text": "The National Herald",
-                                    "_title": "The National Herald",
-                                    "_xmlUrl": "https://www.thenationalherald.com/feed/",
-                                    "_htmlUrl": "https://www.thenationalherald.com"
-                                },
-                                {
-                                    "_type": "rss",
-                                    "_text": "The National Herald GR",
-                                    "_title": "The National Herald GR",
-                                    "_xmlUrl": "https://www.ekirikas.com/feed/",
-                                    "_htmlUrl": "https://www.ekirikas.com"
-                                }
-                            ],
-                            "_text": "ekirikas",
-                            "_title": "ekirikas"
-                        }
-                    ],
-                    "_text": "greek-english",
-                    "_title": "greek-english"
+                    "_type": "rss",
+                    "_text": "ekathimerini.com",
+                    "_title": "ekathimerini.com",
+                    "_xmlUrl": "http://www.ekathimerini.com/rss",
+                    "_htmlUrl": "http://www.ekathimerini.com/"
                 },
                 {
-                    "outline": [
-                        {
-                            "outline": [
-                                {
-                                    "_type": "rss",
-                                    "_text": "조선닷컴 : 전체기사",
-                                    "_title": "조선닷컴 : 전체기사",
-                                    "_xmlUrl": "http://www.chosun.com/site/data/rss/rss.xml",
-                                    "_htmlUrl": "http://www.chosun.com"
-                                },
-                                {
-                                    "_type": "rss",
-                                    "_text": "The Chosun Ilbo",
-                                    "_title": "The Chosun Ilbo",
-                                    "_xmlUrl": "http://english.chosun.com/site/data/rss/rss.xml",
-                                    "_htmlUrl": "http://english.chosun.com"
-                                }
-                            ],
-                            "_text": "chosun",
-                            "_title": "chosun"
-                        },
-                        {
-                            "outline": [
-                                {
-                                    "_type": "rss",
-                                    "_text": "한국일보 주요기사",
-                                    "_title": "한국일보 주요기사",
-                                    "_xmlUrl": "http://rss.hankookilbo.com/rss_xml/main/mainpan.xml",
-                                    "_htmlUrl": "http://www.hankookilbo.com/"
-                                },
-                                {
-                                    "_type": "rss",
-                                    "_text": "Korea Times News",
-                                    "_title": "Korea Times News",
-                                    "_xmlUrl": "http://www.ktimes.com/www/rss/rss.xml",
-                                    "_htmlUrl": "http://www.koreatimes.co.kr/"
-                                }
-                            ],
-                            "_text": "hankook",
-                            "_title": "hankook"
-                        },
-                        {
-                            "outline": [
-                                {
-                                    "_type": "rss",
-                                    "_text": "전체기사 : 뉴스 : 한겨레 뉴스 - 인터넷한겨레",
-                                    "_title": "전체기사 : 뉴스 : 한겨레 뉴스 - 인터넷한겨레",
-                                    "_xmlUrl": "http://www.hani.co.kr/rss/",
-                                    "_htmlUrl": "http://www.hani.co.kr/arti/"
-                                },
-                                {
-                                    "_type": "rss",
-                                    "_text": "English Edition : The hankyoreh",
-                                    "_title": "English Edition : The hankyoreh",
-                                    "_xmlUrl": "http://english.hani.co.kr/rss/english_edition/",
-                                    "_htmlUrl": "http://english.hani.co.kr"
-                                }
-                            ],
-                            "_text": "hankyoreh",
-                            "_title": "hankyoreh"
-                        }
-                    ],
-                    "_text": "korean-english",
-                    "_title": "korean-english"
+                    "_type": "rss",
+                    "_text": "Η ΚΑΘΗΜΕΡΙΝΗ | Ημερήσια Πολιτική και Οικονομική Εφημερίδα",
+                    "_title": "Η ΚΑΘΗΜΕΡΙΝΗ | Ημερήσια Πολιτική και Οικονομική Εφημερίδα",
+                    "_xmlUrl": "http://www.kathimerini.gr/rss",
+                    "_htmlUrl": "https://www.kathimerini.gr/"
                 },
                 {
-                    "outline": [
-                        {
-                            "outline": [
-                                {
-                                    "_type": "rss",
-                                    "_text": "Granma - Órgano oficial del Partido Comunista de Cuba",
-                                    "_title": "Granma - Órgano oficial del Partido Comunista de Cuba",
-                                    "_xmlUrl": "http://www.granma.cu/feed",
-                                    "_htmlUrl": "http://www.granma.cu"
-                                },
-                                {
-                                    "_type": "rss",
-                                    "_text": "Granma - Órgano oficial del Partido Comunista de Cuba",
-                                    "_title": "Granma - Órgano oficial del Partido Comunista de Cuba",
-                                    "_xmlUrl": "http://en.granma.cu/feed",
-                                    "_htmlUrl": "http://en.granma.cu"
-                                }
-                            ],
-                            "_text": "granma",
-                            "_title": "granma"
-                        },
-                        {
-                            "outline": [
-                                {
-                                    "_type": "rss",
-                                    "_text": "Agencia EFE | www.efe.com | Edición España",
-                                    "_title": "Agencia EFE | www.efe.com | Edición España",
-                                    "_xmlUrl": "http://www.efe.com/efe/noticias/espana/1/rss",
-                                    "_htmlUrl": "https://www.efe.com/efe/espana/1/rss"
-                                },
-                                {
-                                    "_type": "rss",
-                                    "_text": "Agencia EFE | www.efe.com | English edition",
-                                    "_title": "Agencia EFE | www.efe.com | English edition",
-                                    "_xmlUrl": "http://www.efe.com/efe/noticias/english/4/rss",
-                                    "_htmlUrl": "https://www.efe.com/efe/english/4/rss"
-                                }
-                            ],
-                            "_text": "efe",
-                            "_title": "efe"
-                        },
-                        {
-                            "outline": [
-                                {
-                                    "_type": "rss",
-                                    "_text": "In English Section | EL PAÍS",
-                                    "_title": "In English Section | EL PAÍS",
-                                    "_xmlUrl": "http://ep01.epimg.net/rss/elpais/inenglish.xml",
-                                    "_htmlUrl": "https://elpais.com/rss/elpais/inenglish.xml"
-                                },
-                                {
-                                    "_type": "rss",
-                                    "_text": "Portada de EL PAÍS",
-                                    "_title": "Portada de EL PAÍS",
-                                    "_xmlUrl": "http://www.elpais.com/rss/feed.html?feedId=1022",
-                                    "_htmlUrl": "https://elpais.com/rss/elpais/portada.xml"
-                                }
-                            ],
-                            "_text": "elpais",
-                            "_title": "elpais"
-                        },
-                        {
-                            "outline": [
-                                {
-                                    "_type": "rss",
-                                    "_text": "GARA Euskal Herriko egunkaria | naiz.eus",
-                                    "_title": "GARA Euskal Herriko egunkaria | naiz.eus",
-                                    "_xmlUrl": "https://www.naiz.eus/es/rss/publications/gara.rss",
-                                    "_htmlUrl": "https://www.naiz.eus/es/rss/publications/gara.rss"
-                                },
-                                {
-                                    "_type": "rss",
-                                    "_text": "GARA Euskal Herriko egunkaria | naiz.eus | English",
-                                    "_title": "GARA Euskal Herriko egunkaria | naiz.eus | English",
-                                    "_xmlUrl": "https://www.naiz.eus/en/rss/publications/gara.rss",
-                                    "_htmlUrl": "https://www.naiz.eus/en/rss/publications/gara.rss"
-                                }
-                            ],
-                            "_text": "gara",
-                            "_title": "gara"
-                        }
-                    ],
-                    "_text": "spanish-english",
-                    "_title": "spanish-english"
+                    "_type": "rss",
+                    "_text": "ert.gr",
+                    "_title": "ert.gr",
+                    "_xmlUrl": "https://www.ert.gr/feed/",
+                    "_htmlUrl": "https://www.ert.gr"
                 },
                 {
-                    "outline": {
-                        "outline": [
-                            {
-                                "_type": "rss",
-                                "_text": "BBC News 코리아 - 홈페이지",
-                                "_title": "BBC News 코리아 - 홈페이지",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/korean/rss.xml",
-                                "_htmlUrl": "https://www.bbckorean.com"
-                            },
-                            {
-                                "_type": "rss",
-                                "_text": "BBC News - World",
-                                "_title": "BBC News - World",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/news/world/rss.xml",
-                                "_htmlUrl": "https://www.bbc.co.uk/news/"
-                            },
-                            {
-                                "_type": "rss",
-                                "_text": "BBC Uzbek - Бош саҳифа",
-                                "_title": "BBC Uzbek - Бош саҳифа",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/uzbek/rss.xml",
-                                "_htmlUrl": "http://www.bbcuzbek.com"
-                            },
-                            {
-                                "_type": "rss",
-                                "_text": "BBC News Україна - Новини",
-                                "_title": "BBC News Україна - Новини",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/ukrainian/rss.xml",
-                                "_htmlUrl": "http://www.bbcukrainian.com"
-                            },
-                            {
-                                "_type": "rss",
-                                "_text": "BBC News Indonesia - Berita",
-                                "_title": "BBC News Indonesia - Berita",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/indonesia/rss.xml",
-                                "_htmlUrl": "http://www.bbcindonesia.com"
-                            },
-                            {
-                                "_type": "rss",
-                                "_text": "BBC Mundo - Noticias",
-                                "_title": "BBC Mundo - Noticias",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/mundo/rss.xml",
-                                "_htmlUrl": "http://www.bbcmundo.com"
-                            },
-                            {
-                                "_type": "rss",
-                                "_text": "BBC News اردو - خبریں، تازہ خبریں، بریکنگ نیو | News, latest news, breaking news",
-                                "_title": "BBC News اردو - خبریں، تازہ خبریں، بریکنگ نیو | News, latest news, breaking news",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/urdu/rss.xml",
-                                "_htmlUrl": "http://www.bbcurdu.com"
-                            },
-                            {
-                                "_type": "rss",
-                                "_text": "BBC Russian - Главная",
-                                "_title": "BBC Russian - Главная",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/russian/rss.xml",
-                                "_htmlUrl": "http://www.bbcrussian.com"
-                            },
-                            {
-                                "_type": "rss",
-                                "_text": "BBC News தமிழ் - முகப்பு",
-                                "_title": "BBC News தமிழ் - முகப்பு",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/tamil/rss.xml",
-                                "_htmlUrl": "http://www.bbctamil.com"
-                            },
-                            {
-                                "_type": "rss",
-                                "_text": "BBC News Tiếng Việt - Tin chính",
-                                "_title": "BBC News Tiếng Việt - Tin chính",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/vietnamese/rss.xml",
-                                "_htmlUrl": "http://www.bbcvietnamese.com"
-                            },
-                            {
-                                "_type": "rss",
-                                "_text": "BBC News नेपाल - समाचार, भर्खरै प्राप्त समाचार, भिडिओ, विश्लेषण, प्रतिक्रिया | बीबीसी नेपाली",
-                                "_title": "BBC News नेपाल - समाचार, भर्खरै प्राप्त समाचार, भिडिओ, विश्लेषण, प्रतिक्रिया | बीबीसी नेपाली",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/nepali/rss.xml",
-                                "_htmlUrl": "http://www.bbcnepali.com"
-                            },
-                            {
-                                "_type": "rss",
-                                "_text": "BBC Brasil - Notícias, vídeos, análise e contexto em português",
-                                "_title": "BBC Brasil - Notícias, vídeos, análise e contexto em português",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/portuguese/rss.xml",
-                                "_htmlUrl": "http://www.bbcbrasil.com"
-                            },
-                            {
-                                "_type": "rss",
-                                "_text": "BBC Turkish - Haberler, Son Dakika Haberleri, Haber-Analiz, Video",
-                                "_title": "BBC Turkish - Haberler, Son Dakika Haberleri, Haber-Analiz, Video",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/turkce/rss.xml",
-                                "_htmlUrl": "http://www.bbcturkce.com"
-                            },
-                            {
-                                "_type": "rss",
-                                "_text": "BBC Cymru Fyw - Newyddion a mwy",
-                                "_title": "BBC Cymru Fyw - Newyddion a mwy",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/cymrufyw/rss.xml",
-                                "_htmlUrl": "http://www.bbc.co.uk/cymrufyw"
-                            },
-                            {
-                                "_type": "rss",
-                                "_text": "BBC Chinese - 主页",
-                                "_title": "BBC Chinese - 主页",
-                                "_xmlUrl": "http://feeds.bbci.co.uk/zhongwen/simp/rss.xml",
-                                "_htmlUrl": "http://www.bbcchinese.com"
-                            }
-                        ],
-                        "_text": "bbc",
-                        "_title": "bbc"
-                    },
-                    "_text": "multilingual",
-                    "_title": "multilingual"
+                    "_type": "rss",
+                    "_text": "ERT International",
+                    "_title": "ERT International",
+                    "_xmlUrl": "https://int.ert.gr/feed/",
+                    "_htmlUrl": "https://int.ert.gr"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "The National Herald",
+                    "_title": "The National Herald",
+                    "_xmlUrl": "https://www.thenationalherald.com/feed/",
+                    "_htmlUrl": "https://www.thenationalherald.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "The National Herald GR",
+                    "_title": "The National Herald GR",
+                    "_xmlUrl": "https://www.ekirikas.com/feed/",
+                    "_htmlUrl": "https://www.ekirikas.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "조선닷컴 : 전체기사",
+                    "_title": "조선닷컴 : 전체기사",
+                    "_xmlUrl": "http://www.chosun.com/site/data/rss/rss.xml",
+                    "_htmlUrl": "http://www.chosun.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "The Chosun Ilbo",
+                    "_title": "The Chosun Ilbo",
+                    "_xmlUrl": "http://english.chosun.com/site/data/rss/rss.xml",
+                    "_htmlUrl": "http://english.chosun.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "한국일보 주요기사",
+                    "_title": "한국일보 주요기사",
+                    "_xmlUrl": "http://rss.hankookilbo.com/rss_xml/main/mainpan.xml",
+                    "_htmlUrl": "http://www.hankookilbo.com/"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "Korea Times News",
+                    "_title": "Korea Times News",
+                    "_xmlUrl": "http://www.ktimes.com/www/rss/rss.xml",
+                    "_htmlUrl": "http://www.koreatimes.co.kr/"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "전체기사 : 뉴스 : 한겨레 뉴스 - 인터넷한겨레",
+                    "_title": "전체기사 : 뉴스 : 한겨레 뉴스 - 인터넷한겨레",
+                    "_xmlUrl": "http://www.hani.co.kr/rss/",
+                    "_htmlUrl": "http://www.hani.co.kr/arti/"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "English Edition : The hankyoreh",
+                    "_title": "English Edition : The hankyoreh",
+                    "_xmlUrl": "http://english.hani.co.kr/rss/english_edition/",
+                    "_htmlUrl": "http://english.hani.co.kr"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "Granma - Órgano oficial del Partido Comunista de Cuba",
+                    "_title": "Granma - Órgano oficial del Partido Comunista de Cuba",
+                    "_xmlUrl": "http://www.granma.cu/feed",
+                    "_htmlUrl": "http://www.granma.cu"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "Granma - Órgano oficial del Partido Comunista de Cuba",
+                    "_title": "Granma - Órgano oficial del Partido Comunista de Cuba",
+                    "_xmlUrl": "http://en.granma.cu/feed",
+                    "_htmlUrl": "http://en.granma.cu"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "Agencia EFE | www.efe.com | Edición España",
+                    "_title": "Agencia EFE | www.efe.com | Edición España",
+                    "_xmlUrl": "http://www.efe.com/efe/noticias/espana/1/rss",
+                    "_htmlUrl": "https://www.efe.com/efe/espana/1/rss"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "Agencia EFE | www.efe.com | English edition",
+                    "_title": "Agencia EFE | www.efe.com | English edition",
+                    "_xmlUrl": "http://www.efe.com/efe/noticias/english/4/rss",
+                    "_htmlUrl": "https://www.efe.com/efe/english/4/rss"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "In English Section | EL PAÍS",
+                    "_title": "In English Section | EL PAÍS",
+                    "_xmlUrl": "http://ep01.epimg.net/rss/elpais/inenglish.xml",
+                    "_htmlUrl": "https://elpais.com/rss/elpais/inenglish.xml"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "Portada de EL PAÍS",
+                    "_title": "Portada de EL PAÍS",
+                    "_xmlUrl": "http://www.elpais.com/rss/feed.html?feedId=1022",
+                    "_htmlUrl": "https://elpais.com/rss/elpais/portada.xml"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "GARA Euskal Herriko egunkaria | naiz.eus",
+                    "_title": "GARA Euskal Herriko egunkaria | naiz.eus",
+                    "_xmlUrl": "https://www.naiz.eus/es/rss/publications/gara.rss",
+                    "_htmlUrl": "https://www.naiz.eus/es/rss/publications/gara.rss"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "GARA Euskal Herriko egunkaria | naiz.eus | English",
+                    "_title": "GARA Euskal Herriko egunkaria | naiz.eus | English",
+                    "_xmlUrl": "https://www.naiz.eus/en/rss/publications/gara.rss",
+                    "_htmlUrl": "https://www.naiz.eus/en/rss/publications/gara.rss"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC News 코리아 - 홈페이지",
+                    "_title": "BBC News 코리아 - 홈페이지",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/korean/rss.xml",
+                    "_htmlUrl": "https://www.bbckorean.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC News - World",
+                    "_title": "BBC News - World",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/news/world/rss.xml",
+                    "_htmlUrl": "https://www.bbc.co.uk/news/"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC Uzbek - Бош саҳифа",
+                    "_title": "BBC Uzbek - Бош саҳифа",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/uzbek/rss.xml",
+                    "_htmlUrl": "http://www.bbcuzbek.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC News Україна - Новини",
+                    "_title": "BBC News Україна - Новини",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/ukrainian/rss.xml",
+                    "_htmlUrl": "http://www.bbcukrainian.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC News Indonesia - Berita",
+                    "_title": "BBC News Indonesia - Berita",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/indonesia/rss.xml",
+                    "_htmlUrl": "http://www.bbcindonesia.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC Mundo - Noticias",
+                    "_title": "BBC Mundo - Noticias",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/mundo/rss.xml",
+                    "_htmlUrl": "http://www.bbcmundo.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC News اردو - خبریں، تازہ خبریں، بریکنگ نیو | News, latest news, breaking news",
+                    "_title": "BBC News اردو - خبریں، تازہ خبریں، بریکنگ نیو | News, latest news, breaking news",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/urdu/rss.xml",
+                    "_htmlUrl": "http://www.bbcurdu.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC Russian - Главная",
+                    "_title": "BBC Russian - Главная",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/russian/rss.xml",
+                    "_htmlUrl": "http://www.bbcrussian.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC News தமிழ் - முகப்பு",
+                    "_title": "BBC News தமிழ் - முகப்பு",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/tamil/rss.xml",
+                    "_htmlUrl": "http://www.bbctamil.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC News Tiếng Việt - Tin chính",
+                    "_title": "BBC News Tiếng Việt - Tin chính",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/vietnamese/rss.xml",
+                    "_htmlUrl": "http://www.bbcvietnamese.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC News नेपाल - समाचार, भर्खरै प्राप्त समाचार, भिडिओ, विश्लेषण, प्रतिक्रिया | बीबीसी नेपाली",
+                    "_title": "BBC News नेपाल - समाचार, भर्खरै प्राप्त समाचार, भिडिओ, विश्लेषण, प्रतिक्रिया | बीबीसी नेपाली",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/nepali/rss.xml",
+                    "_htmlUrl": "http://www.bbcnepali.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC Brasil - Notícias, vídeos, análise e contexto em português",
+                    "_title": "BBC Brasil - Notícias, vídeos, análise e contexto em português",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/portuguese/rss.xml",
+                    "_htmlUrl": "http://www.bbcbrasil.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC Turkish - Haberler, Son Dakika Haberleri, Haber-Analiz, Video",
+                    "_title": "BBC Turkish - Haberler, Son Dakika Haberleri, Haber-Analiz, Video",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/turkce/rss.xml",
+                    "_htmlUrl": "http://www.bbcturkce.com"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC Cymru Fyw - Newyddion a mwy",
+                    "_title": "BBC Cymru Fyw - Newyddion a mwy",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/cymrufyw/rss.xml",
+                    "_htmlUrl": "http://www.bbc.co.uk/cymrufyw"
+                },
+                {
+                    "_type": "rss",
+                    "_text": "BBC Chinese - 主页",
+                    "_title": "BBC Chinese - 主页",
+                    "_xmlUrl": "http://feeds.bbci.co.uk/zhongwen/simp/rss.xml",
+                    "_htmlUrl": "http://www.bbcchinese.com"
                 }
             ]
         },

--- a/fixtures/feedly.opml
+++ b/fixtures/feedly.opml
@@ -4,59 +4,40 @@
 		<title>Kansas subscriptions in feedly Cloud</title>
 	</head>
 	<body>
-		<outline text="greek-english" title="greek-english">
-			<outline text="kathimerini" title="kathimerini">
-				<outline type="rss" text="ekathimerini.com" title="ekathimerini.com" xmlUrl="http://www.ekathimerini.com/rss" htmlUrl="http://www.ekathimerini.com/"/>
-				<outline type="rss" text="Η ΚΑΘΗΜΕΡΙΝΗ | Ημερήσια Πολιτική και Οικονομική Εφημερίδα" title="Η ΚΑΘΗΜΕΡΙΝΗ | Ημερήσια Πολιτική και Οικονομική Εφημερίδα" xmlUrl="http://www.kathimerini.gr/rss" htmlUrl="https://www.kathimerini.gr/"/></outline>
-			<outline text="ert" title="ert">
-				<outline type="rss" text="ert.gr" title="ert.gr" xmlUrl="https://www.ert.gr/feed/" htmlUrl="https://www.ert.gr"/>
-				<outline type="rss" text="ERT International" title="ERT International" xmlUrl="https://int.ert.gr/feed/" htmlUrl="https://int.ert.gr"/></outline>
-			<outline text="ekirikas" title="ekirikas">
-				<outline type="rss" text="The National Herald" title="The National Herald" xmlUrl="https://www.thenationalherald.com/feed/" htmlUrl="https://www.thenationalherald.com"/>
-				<outline type="rss" text="The National Herald GR" title="The National Herald GR" xmlUrl="https://www.ekirikas.com/feed/" htmlUrl="https://www.ekirikas.com"/></outline>
-		</outline>
-		<outline text="korean-english" title="korean-english">
-			<outline text="chosun" title="chosun">
-				<outline type="rss" text="조선닷컴 : 전체기사" title="조선닷컴 : 전체기사" xmlUrl="http://www.chosun.com/site/data/rss/rss.xml" htmlUrl="http://www.chosun.com"/>
-				<outline type="rss" text="The Chosun Ilbo" title="The Chosun Ilbo" xmlUrl="http://english.chosun.com/site/data/rss/rss.xml" htmlUrl="http://english.chosun.com"/></outline>
-			<outline text="hankook" title="hankook">
-				<outline type="rss" text="한국일보 주요기사" title="한국일보 주요기사" xmlUrl="http://rss.hankookilbo.com/rss_xml/main/mainpan.xml" htmlUrl="http://www.hankookilbo.com/"/>
-				<outline type="rss" text="Korea Times News" title="Korea Times News" xmlUrl="http://www.ktimes.com/www/rss/rss.xml" htmlUrl="http://www.koreatimes.co.kr/"/></outline>
-			<outline text="hankyoreh" title="hankyoreh">
-				<outline type="rss" text="전체기사 : 뉴스 : 한겨레 뉴스 - 인터넷한겨레" title="전체기사 : 뉴스 : 한겨레 뉴스 - 인터넷한겨레" xmlUrl="http://www.hani.co.kr/rss/" htmlUrl="http://www.hani.co.kr/arti/"/>
-				<outline type="rss" text="English Edition : The hankyoreh" title="English Edition : The hankyoreh" xmlUrl="http://english.hani.co.kr/rss/english_edition/" htmlUrl="http://english.hani.co.kr"/></outline>
-		</outline>
-		<outline text="spanish-english" title="spanish-english">
-			<outline text="granma" title="granma">
-				<outline type="rss" text="Granma - Órgano oficial del Partido Comunista de Cuba" title="Granma - Órgano oficial del Partido Comunista de Cuba" xmlUrl="http://www.granma.cu/feed" htmlUrl="http://www.granma.cu"/>
-				<outline type="rss" text="Granma - Órgano oficial del Partido Comunista de Cuba" title="Granma - Órgano oficial del Partido Comunista de Cuba" xmlUrl="http://en.granma.cu/feed" htmlUrl="http://en.granma.cu"/></outline>
-			<outline text="efe" title="efe">
-				<outline type="rss" text="Agencia EFE | www.efe.com | Edición España" title="Agencia EFE | www.efe.com | Edición España" xmlUrl="http://www.efe.com/efe/noticias/espana/1/rss" htmlUrl="https://www.efe.com/efe/espana/1/rss"/>
-				<outline type="rss" text="Agencia EFE | www.efe.com | English edition" title="Agencia EFE | www.efe.com | English edition" xmlUrl="http://www.efe.com/efe/noticias/english/4/rss" htmlUrl="https://www.efe.com/efe/english/4/rss"/></outline>
-			<outline text="elpais" title="elpais">
-				<outline type="rss" text="In English Section | EL PAÍS" title="In English Section | EL PAÍS" xmlUrl="http://ep01.epimg.net/rss/elpais/inenglish.xml" htmlUrl="https://elpais.com/rss/elpais/inenglish.xml"/>
-				<outline type="rss" text="Portada de EL PAÍS" title="Portada de EL PAÍS" xmlUrl="http://www.elpais.com/rss/feed.html?feedId=1022" htmlUrl="https://elpais.com/rss/elpais/portada.xml"/></outline>
-			<outline text="gara" title="gara">
-				<outline type="rss" text="GARA Euskal Herriko egunkaria | naiz.eus" title="GARA Euskal Herriko egunkaria | naiz.eus" xmlUrl="https://www.naiz.eus/es/rss/publications/gara.rss" htmlUrl="https://www.naiz.eus/es/rss/publications/gara.rss"/>
-				<outline type="rss" text="GARA Euskal Herriko egunkaria | naiz.eus | English" title="GARA Euskal Herriko egunkaria | naiz.eus | English" xmlUrl="https://www.naiz.eus/en/rss/publications/gara.rss" htmlUrl="https://www.naiz.eus/en/rss/publications/gara.rss"/></outline>
-		</outline>
-		<outline text="multilingual" title="multilingual">
-			<outline text="bbc" title="bbc">
-				<outline type="rss" text="BBC News 코리아 - 홈페이지" title="BBC News 코리아 - 홈페이지" xmlUrl="http://feeds.bbci.co.uk/korean/rss.xml" htmlUrl="https://www.bbckorean.com"/>
-				<outline type="rss" text="BBC News - World" title="BBC News - World" xmlUrl="http://feeds.bbci.co.uk/news/world/rss.xml" htmlUrl="https://www.bbc.co.uk/news/"/>
-				<outline type="rss" text="BBC Uzbek - Бош саҳифа" title="BBC Uzbek - Бош саҳифа" xmlUrl="http://feeds.bbci.co.uk/uzbek/rss.xml" htmlUrl="http://www.bbcuzbek.com"/>
-				<outline type="rss" text="BBC News Україна - Новини" title="BBC News Україна - Новини" xmlUrl="http://feeds.bbci.co.uk/ukrainian/rss.xml" htmlUrl="http://www.bbcukrainian.com"/>
-				<outline type="rss" text="BBC News Indonesia - Berita" title="BBC News Indonesia - Berita" xmlUrl="http://feeds.bbci.co.uk/indonesia/rss.xml" htmlUrl="http://www.bbcindonesia.com"/>
-				<outline type="rss" text="BBC Mundo - Noticias" title="BBC Mundo - Noticias" xmlUrl="http://feeds.bbci.co.uk/mundo/rss.xml" htmlUrl="http://www.bbcmundo.com"/>
-				<outline type="rss" text="BBC News اردو - خبریں، تازہ خبریں، بریکنگ نیو | News, latest news, breaking news" title="BBC News اردو - خبریں، تازہ خبریں، بریکنگ نیو | News, latest news, breaking news" xmlUrl="http://feeds.bbci.co.uk/urdu/rss.xml" htmlUrl="http://www.bbcurdu.com"/>
-				<outline type="rss" text="BBC Russian - Главная" title="BBC Russian - Главная" xmlUrl="http://feeds.bbci.co.uk/russian/rss.xml" htmlUrl="http://www.bbcrussian.com"/>
-				<outline type="rss" text="BBC News தமிழ் - முகப்பு" title="BBC News தமிழ் - முகப்பு" xmlUrl="http://feeds.bbci.co.uk/tamil/rss.xml" htmlUrl="http://www.bbctamil.com"/>
-				<outline type="rss" text="BBC News Tiếng Việt - Tin chính" title="BBC News Tiếng Việt - Tin chính" xmlUrl="http://feeds.bbci.co.uk/vietnamese/rss.xml" htmlUrl="http://www.bbcvietnamese.com"/>
-				<outline type="rss" text="BBC News नेपाल - समाचार, भर्खरै प्राप्त समाचार, भिडिओ, विश्लेषण, प्रतिक्रिया | बीबीसी नेपाली" title="BBC News नेपाल - समाचार, भर्खरै प्राप्त समाचार, भिडिओ, विश्लेषण, प्रतिक्रिया | बीबीसी नेपाली" xmlUrl="http://feeds.bbci.co.uk/nepali/rss.xml" htmlUrl="http://www.bbcnepali.com"/>
-				<outline type="rss" text="BBC Brasil - Notícias, vídeos, análise e contexto em português" title="BBC Brasil - Notícias, vídeos, análise e contexto em português" xmlUrl="http://feeds.bbci.co.uk/portuguese/rss.xml" htmlUrl="http://www.bbcbrasil.com"/>
-				<outline type="rss" text="BBC Turkish - Haberler, Son Dakika Haberleri, Haber-Analiz, Video" title="BBC Turkish - Haberler, Son Dakika Haberleri, Haber-Analiz, Video" xmlUrl="http://feeds.bbci.co.uk/turkce/rss.xml" htmlUrl="http://www.bbcturkce.com"/>
-				<outline type="rss" text="BBC Cymru Fyw - Newyddion a mwy" title="BBC Cymru Fyw - Newyddion a mwy" xmlUrl="http://feeds.bbci.co.uk/cymrufyw/rss.xml" htmlUrl="http://www.bbc.co.uk/cymrufyw"/>
-				<outline type="rss" text="BBC Chinese - 主页" title="BBC Chinese - 主页" xmlUrl="http://feeds.bbci.co.uk/zhongwen/simp/rss.xml" htmlUrl="http://www.bbcchinese.com"/></outline>
-		</outline>
+		<outline type="rss" text="ekathimerini.com" title="ekathimerini.com" xmlUrl="http://www.ekathimerini.com/rss" htmlUrl="http://www.ekathimerini.com/"/>
+		<outline type="rss" text="Η ΚΑΘΗΜΕΡΙΝΗ | Ημερήσια Πολιτική και Οικονομική Εφημερίδα" title="Η ΚΑΘΗΜΕΡΙΝΗ | Ημερήσια Πολιτική και Οικονομική Εφημερίδα" xmlUrl="http://www.kathimerini.gr/rss" htmlUrl="https://www.kathimerini.gr/"/>
+		<outline type="rss" text="ert.gr" title="ert.gr" xmlUrl="https://www.ert.gr/feed/" htmlUrl="https://www.ert.gr"/>
+		<outline type="rss" text="ERT International" title="ERT International" xmlUrl="https://int.ert.gr/feed/" htmlUrl="https://int.ert.gr"/>
+		<outline type="rss" text="The National Herald" title="The National Herald" xmlUrl="https://www.thenationalherald.com/feed/" htmlUrl="https://www.thenationalherald.com"/>
+		<outline type="rss" text="The National Herald GR" title="The National Herald GR" xmlUrl="https://www.ekirikas.com/feed/" htmlUrl="https://www.ekirikas.com"/>
+		<outline type="rss" text="조선닷컴 : 전체기사" title="조선닷컴 : 전체기사" xmlUrl="http://www.chosun.com/site/data/rss/rss.xml" htmlUrl="http://www.chosun.com"/>
+		<outline type="rss" text="The Chosun Ilbo" title="The Chosun Ilbo" xmlUrl="http://english.chosun.com/site/data/rss/rss.xml" htmlUrl="http://english.chosun.com"/>
+		<outline type="rss" text="한국일보 주요기사" title="한국일보 주요기사" xmlUrl="http://rss.hankookilbo.com/rss_xml/main/mainpan.xml" htmlUrl="http://www.hankookilbo.com/"/>
+		<outline type="rss" text="Korea Times News" title="Korea Times News" xmlUrl="http://www.ktimes.com/www/rss/rss.xml" htmlUrl="http://www.koreatimes.co.kr/"/>
+		<outline type="rss" text="전체기사 : 뉴스 : 한겨레 뉴스 - 인터넷한겨레" title="전체기사 : 뉴스 : 한겨레 뉴스 - 인터넷한겨레" xmlUrl="http://www.hani.co.kr/rss/" htmlUrl="http://www.hani.co.kr/arti/"/>
+		<outline type="rss" text="English Edition : The hankyoreh" title="English Edition : The hankyoreh" xmlUrl="http://english.hani.co.kr/rss/english_edition/" htmlUrl="http://english.hani.co.kr"/>
+		<outline type="rss" text="Granma - Órgano oficial del Partido Comunista de Cuba" title="Granma - Órgano oficial del Partido Comunista de Cuba" xmlUrl="http://www.granma.cu/feed" htmlUrl="http://www.granma.cu"/>
+		<outline type="rss" text="Granma - Órgano oficial del Partido Comunista de Cuba" title="Granma - Órgano oficial del Partido Comunista de Cuba" xmlUrl="http://en.granma.cu/feed" htmlUrl="http://en.granma.cu"/>
+		<outline type="rss" text="Agencia EFE | www.efe.com | Edición España" title="Agencia EFE | www.efe.com | Edición España" xmlUrl="http://www.efe.com/efe/noticias/espana/1/rss" htmlUrl="https://www.efe.com/efe/espana/1/rss"/>
+		<outline type="rss" text="Agencia EFE | www.efe.com | English edition" title="Agencia EFE | www.efe.com | English edition" xmlUrl="http://www.efe.com/efe/noticias/english/4/rss" htmlUrl="https://www.efe.com/efe/english/4/rss"/>
+		<outline type="rss" text="In English Section | EL PAÍS" title="In English Section | EL PAÍS" xmlUrl="http://ep01.epimg.net/rss/elpais/inenglish.xml" htmlUrl="https://elpais.com/rss/elpais/inenglish.xml"/>
+		<outline type="rss" text="Portada de EL PAÍS" title="Portada de EL PAÍS" xmlUrl="http://www.elpais.com/rss/feed.html?feedId=1022" htmlUrl="https://elpais.com/rss/elpais/portada.xml"/>
+		<outline type="rss" text="GARA Euskal Herriko egunkaria | naiz.eus" title="GARA Euskal Herriko egunkaria | naiz.eus" xmlUrl="https://www.naiz.eus/es/rss/publications/gara.rss" htmlUrl="https://www.naiz.eus/es/rss/publications/gara.rss"/>
+		<outline type="rss" text="GARA Euskal Herriko egunkaria | naiz.eus | English" title="GARA Euskal Herriko egunkaria | naiz.eus | English" xmlUrl="https://www.naiz.eus/en/rss/publications/gara.rss" htmlUrl="https://www.naiz.eus/en/rss/publications/gara.rss"/>
+		<outline type="rss" text="BBC News 코리아 - 홈페이지" title="BBC News 코리아 - 홈페이지" xmlUrl="http://feeds.bbci.co.uk/korean/rss.xml" htmlUrl="https://www.bbckorean.com"/>
+		<outline type="rss" text="BBC News - World" title="BBC News - World" xmlUrl="http://feeds.bbci.co.uk/news/world/rss.xml" htmlUrl="https://www.bbc.co.uk/news/"/>
+		<outline type="rss" text="BBC Uzbek - Бош саҳифа" title="BBC Uzbek - Бош саҳифа" xmlUrl="http://feeds.bbci.co.uk/uzbek/rss.xml" htmlUrl="http://www.bbcuzbek.com"/>
+		<outline type="rss" text="BBC News Україна - Новини" title="BBC News Україна - Новини" xmlUrl="http://feeds.bbci.co.uk/ukrainian/rss.xml" htmlUrl="http://www.bbcukrainian.com"/>
+		<outline type="rss" text="BBC News Indonesia - Berita" title="BBC News Indonesia - Berita" xmlUrl="http://feeds.bbci.co.uk/indonesia/rss.xml" htmlUrl="http://www.bbcindonesia.com"/>
+		<outline type="rss" text="BBC Mundo - Noticias" title="BBC Mundo - Noticias" xmlUrl="http://feeds.bbci.co.uk/mundo/rss.xml" htmlUrl="http://www.bbcmundo.com"/>
+		<outline type="rss" text="BBC News اردو - خبریں، تازہ خبریں، بریکنگ نیو | News, latest news, breaking news" title="BBC News اردو - خبریں، تازہ خبریں، بریکنگ نیو | News, latest news, breaking news" xmlUrl="http://feeds.bbci.co.uk/urdu/rss.xml" htmlUrl="http://www.bbcurdu.com"/>
+		<outline type="rss" text="BBC Russian - Главная" title="BBC Russian - Главная" xmlUrl="http://feeds.bbci.co.uk/russian/rss.xml" htmlUrl="http://www.bbcrussian.com"/>
+		<outline type="rss" text="BBC News தமிழ் - முகப்பு" title="BBC News தமிழ் - முகப்பு" xmlUrl="http://feeds.bbci.co.uk/tamil/rss.xml" htmlUrl="http://www.bbctamil.com"/>
+		<outline type="rss" text="BBC News Tiếng Việt - Tin chính" title="BBC News Tiếng Việt - Tin chính" xmlUrl="http://feeds.bbci.co.uk/vietnamese/rss.xml" htmlUrl="http://www.bbcvietnamese.com"/>
+		<outline type="rss" text="BBC News नेपाल - समाचार, भर्खरै प्राप्त समाचार, भिडिओ, विश्लेषण, प्रतिक्रिया | बीबीसी नेपाली" title="BBC News नेपाल - समाचार, भर्खरै प्राप्त समाचार, भिडिओ, विश्लेषण, प्रतिक्रिया | बीबीसी नेपाली" xmlUrl="http://feeds.bbci.co.uk/nepali/rss.xml" htmlUrl="http://www.bbcnepali.com"/>
+		<outline type="rss" text="BBC Brasil - Notícias, vídeos, análise e contexto em português" title="BBC Brasil - Notícias, vídeos, análise e contexto em português" xmlUrl="http://feeds.bbci.co.uk/portuguese/rss.xml" htmlUrl="http://www.bbcbrasil.com"/>
+		<outline type="rss" text="BBC Turkish - Haberler, Son Dakika Haberleri, Haber-Analiz, Video" title="BBC Turkish - Haberler, Son Dakika Haberleri, Haber-Analiz, Video" xmlUrl="http://feeds.bbci.co.uk/turkce/rss.xml" htmlUrl="http://www.bbcturkce.com"/>
+		<outline type="rss" text="BBC Cymru Fyw - Newyddion a mwy" title="BBC Cymru Fyw - Newyddion a mwy" xmlUrl="http://feeds.bbci.co.uk/cymrufyw/rss.xml" htmlUrl="http://www.bbc.co.uk/cymrufyw"/>
+		<outline type="rss" text="BBC Chinese - 主页" title="BBC Chinese - 主页" xmlUrl="http://feeds.bbci.co.uk/zhongwen/simp/rss.xml" htmlUrl="http://www.bbcchinese.com"/>
 	</body>
 </opml>

--- a/fixtures/feedly.opml
+++ b/fixtures/feedly.opml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+	<head>
+		<title>Kansas subscriptions in feedly Cloud</title>
+	</head>
+	<body>
+		<outline text="greek-english" title="greek-english">
+			<outline text="kathimerini" title="kathimerini">
+				<outline type="rss" text="ekathimerini.com" title="ekathimerini.com" xmlUrl="http://www.ekathimerini.com/rss" htmlUrl="http://www.ekathimerini.com/"/>
+				<outline type="rss" text="Η ΚΑΘΗΜΕΡΙΝΗ | Ημερήσια Πολιτική και Οικονομική Εφημερίδα" title="Η ΚΑΘΗΜΕΡΙΝΗ | Ημερήσια Πολιτική και Οικονομική Εφημερίδα" xmlUrl="http://www.kathimerini.gr/rss" htmlUrl="https://www.kathimerini.gr/"/></outline>
+			<outline text="ert" title="ert">
+				<outline type="rss" text="ert.gr" title="ert.gr" xmlUrl="https://www.ert.gr/feed/" htmlUrl="https://www.ert.gr"/>
+				<outline type="rss" text="ERT International" title="ERT International" xmlUrl="https://int.ert.gr/feed/" htmlUrl="https://int.ert.gr"/></outline>
+			<outline text="ekirikas" title="ekirikas">
+				<outline type="rss" text="The National Herald" title="The National Herald" xmlUrl="https://www.thenationalherald.com/feed/" htmlUrl="https://www.thenationalherald.com"/>
+				<outline type="rss" text="The National Herald GR" title="The National Herald GR" xmlUrl="https://www.ekirikas.com/feed/" htmlUrl="https://www.ekirikas.com"/></outline>
+		</outline>
+		<outline text="korean-english" title="korean-english">
+			<outline text="chosun" title="chosun">
+				<outline type="rss" text="조선닷컴 : 전체기사" title="조선닷컴 : 전체기사" xmlUrl="http://www.chosun.com/site/data/rss/rss.xml" htmlUrl="http://www.chosun.com"/>
+				<outline type="rss" text="The Chosun Ilbo" title="The Chosun Ilbo" xmlUrl="http://english.chosun.com/site/data/rss/rss.xml" htmlUrl="http://english.chosun.com"/></outline>
+			<outline text="hankook" title="hankook">
+				<outline type="rss" text="한국일보 주요기사" title="한국일보 주요기사" xmlUrl="http://rss.hankookilbo.com/rss_xml/main/mainpan.xml" htmlUrl="http://www.hankookilbo.com/"/>
+				<outline type="rss" text="Korea Times News" title="Korea Times News" xmlUrl="http://www.ktimes.com/www/rss/rss.xml" htmlUrl="http://www.koreatimes.co.kr/"/></outline>
+			<outline text="hankyoreh" title="hankyoreh">
+				<outline type="rss" text="전체기사 : 뉴스 : 한겨레 뉴스 - 인터넷한겨레" title="전체기사 : 뉴스 : 한겨레 뉴스 - 인터넷한겨레" xmlUrl="http://www.hani.co.kr/rss/" htmlUrl="http://www.hani.co.kr/arti/"/>
+				<outline type="rss" text="English Edition : The hankyoreh" title="English Edition : The hankyoreh" xmlUrl="http://english.hani.co.kr/rss/english_edition/" htmlUrl="http://english.hani.co.kr"/></outline>
+		</outline>
+		<outline text="spanish-english" title="spanish-english">
+			<outline text="granma" title="granma">
+				<outline type="rss" text="Granma - Órgano oficial del Partido Comunista de Cuba" title="Granma - Órgano oficial del Partido Comunista de Cuba" xmlUrl="http://www.granma.cu/feed" htmlUrl="http://www.granma.cu"/>
+				<outline type="rss" text="Granma - Órgano oficial del Partido Comunista de Cuba" title="Granma - Órgano oficial del Partido Comunista de Cuba" xmlUrl="http://en.granma.cu/feed" htmlUrl="http://en.granma.cu"/></outline>
+			<outline text="efe" title="efe">
+				<outline type="rss" text="Agencia EFE | www.efe.com | Edición España" title="Agencia EFE | www.efe.com | Edición España" xmlUrl="http://www.efe.com/efe/noticias/espana/1/rss" htmlUrl="https://www.efe.com/efe/espana/1/rss"/>
+				<outline type="rss" text="Agencia EFE | www.efe.com | English edition" title="Agencia EFE | www.efe.com | English edition" xmlUrl="http://www.efe.com/efe/noticias/english/4/rss" htmlUrl="https://www.efe.com/efe/english/4/rss"/></outline>
+			<outline text="elpais" title="elpais">
+				<outline type="rss" text="In English Section | EL PAÍS" title="In English Section | EL PAÍS" xmlUrl="http://ep01.epimg.net/rss/elpais/inenglish.xml" htmlUrl="https://elpais.com/rss/elpais/inenglish.xml"/>
+				<outline type="rss" text="Portada de EL PAÍS" title="Portada de EL PAÍS" xmlUrl="http://www.elpais.com/rss/feed.html?feedId=1022" htmlUrl="https://elpais.com/rss/elpais/portada.xml"/></outline>
+			<outline text="gara" title="gara">
+				<outline type="rss" text="GARA Euskal Herriko egunkaria | naiz.eus" title="GARA Euskal Herriko egunkaria | naiz.eus" xmlUrl="https://www.naiz.eus/es/rss/publications/gara.rss" htmlUrl="https://www.naiz.eus/es/rss/publications/gara.rss"/>
+				<outline type="rss" text="GARA Euskal Herriko egunkaria | naiz.eus | English" title="GARA Euskal Herriko egunkaria | naiz.eus | English" xmlUrl="https://www.naiz.eus/en/rss/publications/gara.rss" htmlUrl="https://www.naiz.eus/en/rss/publications/gara.rss"/></outline>
+		</outline>
+		<outline text="multilingual" title="multilingual">
+			<outline text="bbc" title="bbc">
+				<outline type="rss" text="BBC News 코리아 - 홈페이지" title="BBC News 코리아 - 홈페이지" xmlUrl="http://feeds.bbci.co.uk/korean/rss.xml" htmlUrl="https://www.bbckorean.com"/>
+				<outline type="rss" text="BBC News - World" title="BBC News - World" xmlUrl="http://feeds.bbci.co.uk/news/world/rss.xml" htmlUrl="https://www.bbc.co.uk/news/"/>
+				<outline type="rss" text="BBC Uzbek - Бош саҳифа" title="BBC Uzbek - Бош саҳифа" xmlUrl="http://feeds.bbci.co.uk/uzbek/rss.xml" htmlUrl="http://www.bbcuzbek.com"/>
+				<outline type="rss" text="BBC News Україна - Новини" title="BBC News Україна - Новини" xmlUrl="http://feeds.bbci.co.uk/ukrainian/rss.xml" htmlUrl="http://www.bbcukrainian.com"/>
+				<outline type="rss" text="BBC News Indonesia - Berita" title="BBC News Indonesia - Berita" xmlUrl="http://feeds.bbci.co.uk/indonesia/rss.xml" htmlUrl="http://www.bbcindonesia.com"/>
+				<outline type="rss" text="BBC Mundo - Noticias" title="BBC Mundo - Noticias" xmlUrl="http://feeds.bbci.co.uk/mundo/rss.xml" htmlUrl="http://www.bbcmundo.com"/>
+				<outline type="rss" text="BBC News اردو - خبریں، تازہ خبریں، بریکنگ نیو | News, latest news, breaking news" title="BBC News اردو - خبریں، تازہ خبریں، بریکنگ نیو | News, latest news, breaking news" xmlUrl="http://feeds.bbci.co.uk/urdu/rss.xml" htmlUrl="http://www.bbcurdu.com"/>
+				<outline type="rss" text="BBC Russian - Главная" title="BBC Russian - Главная" xmlUrl="http://feeds.bbci.co.uk/russian/rss.xml" htmlUrl="http://www.bbcrussian.com"/>
+				<outline type="rss" text="BBC News தமிழ் - முகப்பு" title="BBC News தமிழ் - முகப்பு" xmlUrl="http://feeds.bbci.co.uk/tamil/rss.xml" htmlUrl="http://www.bbctamil.com"/>
+				<outline type="rss" text="BBC News Tiếng Việt - Tin chính" title="BBC News Tiếng Việt - Tin chính" xmlUrl="http://feeds.bbci.co.uk/vietnamese/rss.xml" htmlUrl="http://www.bbcvietnamese.com"/>
+				<outline type="rss" text="BBC News नेपाल - समाचार, भर्खरै प्राप्त समाचार, भिडिओ, विश्लेषण, प्रतिक्रिया | बीबीसी नेपाली" title="BBC News नेपाल - समाचार, भर्खरै प्राप्त समाचार, भिडिओ, विश्लेषण, प्रतिक्रिया | बीबीसी नेपाली" xmlUrl="http://feeds.bbci.co.uk/nepali/rss.xml" htmlUrl="http://www.bbcnepali.com"/>
+				<outline type="rss" text="BBC Brasil - Notícias, vídeos, análise e contexto em português" title="BBC Brasil - Notícias, vídeos, análise e contexto em português" xmlUrl="http://feeds.bbci.co.uk/portuguese/rss.xml" htmlUrl="http://www.bbcbrasil.com"/>
+				<outline type="rss" text="BBC Turkish - Haberler, Son Dakika Haberleri, Haber-Analiz, Video" title="BBC Turkish - Haberler, Son Dakika Haberleri, Haber-Analiz, Video" xmlUrl="http://feeds.bbci.co.uk/turkce/rss.xml" htmlUrl="http://www.bbcturkce.com"/>
+				<outline type="rss" text="BBC Cymru Fyw - Newyddion a mwy" title="BBC Cymru Fyw - Newyddion a mwy" xmlUrl="http://feeds.bbci.co.uk/cymrufyw/rss.xml" htmlUrl="http://www.bbc.co.uk/cymrufyw"/>
+				<outline type="rss" text="BBC Chinese - 主页" title="BBC Chinese - 主页" xmlUrl="http://feeds.bbci.co.uk/zhongwen/simp/rss.xml" htmlUrl="http://www.bbcchinese.com"/></outline>
+		</outline>
+	</body>
+</opml>

--- a/utils/opml.go
+++ b/utils/opml.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"encoding/xml"
+)
+
+// An OPML struct can be loaded from an OPML file
+type OPML struct {
+	XMLName xml.Name `xml:"opml"`
+	Version string   `xml:"version,attr"`
+	Head    Head     `xml:"head"`
+	Body    Body     `xml:"body"`
+}
+
+// The Head of the opml
+type Head struct {
+	XMLName xml.Name `xml:"head"`
+	Title   string   `xml:"title"`
+}
+
+// The Body of the opml
+type Body struct {
+	XMLName  xml.Name  `xml:"body"`
+	Outlines []Outline `xml:"outline"`
+}
+
+// The Outline of the opml
+type Outline struct {
+	Text    string `xml:"text,attr"`
+	Title   string `xml:"title,attr"`
+	Type    string `xml:"type,attr"`
+	XMLURL  string `xml:"xmlUrl,attr"`
+	HTMLURL string `xml:"htmlUrl,attr"`
+	Favicon string `xml:"rssfr-favicon,attr"`
+}


### PR DESCRIPTION
This PR adds initial feeds for Spanish-English, Korean-English, Greek-English, and multilingual news feeds to a new `fixtures` directory. Since we aren't sure yet whether to go the opml or json route, I've included both for now, though for maintenance purposes it will probably be more convenient to maintain just one, at which point we can delete the one that we don't need directly (and potentially this file will end up living in S3 rather than in the repo anyway). It turns out to be fairly easy to [convert from opml to json](https://codebeautify.org/opmlviewer) though.