### PR TITLE
Language detection error handling

### DIFF
--- a/cmd/baleen/main.go
+++ b/cmd/baleen/main.go
@@ -177,10 +177,17 @@ func run(c *cli.Context) (err error) {
 					fmt.Println(err)
 				}
 
+				var languageCode string
+				if feed.Language != "" {
+					languageCode = slug.Make(feed.Language)
+				} else {
+					languageCode = "unknown"
+				}
+
 				// Make the doc, store it & add to the manifest
 				doc := store.Document{
 					FeedID:       slug.Make(feed.Title),
-					LanguageCode: slug.Make(feed.Language),
+					LanguageCode: languageCode,
 					Year:         year,
 					Month:        month,
 					Day:          day,


### PR DESCRIPTION
Previously if the `gofeed` parser is unable to parse the language the documents were stored with an empty string in the path name on S3. This adds a bit of error handling so that the documents at least get classified into an "unknown" directory.