### PR TITLE
sc-3226 add topics mock data

### DIFF
--- a/web/mock/fake.py
+++ b/web/mock/fake.py
@@ -93,5 +93,28 @@ def generate_vocab_timeline():
     with open('vocab/timeline.json', 'w+') as f:
         json.dump(day_data, f, indent=4)
 
+def generate_topics():
+    if not os.path.exists('topics'):
+        os.makedirs('topics')
+    
+    fake = Faker()
+    start = datetime(2020, 1, 1)
+    days = [start + timedelta(days=x) for x in range(0, 365)]
+    day_data = []
+    for d in days:
+        topics = {}
+        topics['date'] = d.strftime('%Y-%m-%d')
+        langs = {}
+        for lang, locales in languages.items():
+            if random.randint(0, 1) == 0:
+                continue
+            lang_topics = {}
+            for loc in locales:
+                if len(lang_topics) > 0 and random.randint(0, 1) == 0:
+                    continue
+                loc_topics = {}
+                
+
 if __name__ == "__main__":
     generate_vocab()
+    generate_topics()

--- a/web/mock/fake.py
+++ b/web/mock/fake.py
@@ -117,6 +117,7 @@ def generate_topics():
                 for t in range(0, num_topics):
                     topic = {}
                     topic['name'] = fake.word()
+                    topic['score'] = fake.pyfloat(min_value=0, max_value=1)
                     num_phrases = fake.pyint(min_value=5, max_value=10)
                     phrases = []
                     for p in range(0, num_phrases):

--- a/web/mock/fake.py
+++ b/web/mock/fake.py
@@ -112,8 +112,34 @@ def generate_topics():
             for loc in locales:
                 if len(lang_topics) > 0 and random.randint(0, 1) == 0:
                     continue
-                loc_topics = {}
-                
+                loc_topics = []
+                num_topics = fake.pyint(min_value=1, max_value=5)
+                for t in range(0, num_topics):
+                    topic = {}
+                    topic['name'] = fake.word()
+                    num_phrases = fake.pyint(min_value=5, max_value=10)
+                    phrases = []
+                    for p in range(0, num_phrases):
+                        phrase = {}
+                        phrase['text'] = fake.word()
+                        phrase['score'] = fake.pyfloat(min_value=0, max_value=1)
+                        phrases.append(phrase)
+                    topic['phrases'] = phrases
+                    num_documents = fake.pyint(min_value=1, max_value=10)
+                    documents = []
+                    for doc in range(0, num_documents):
+                        document = {}
+                        document['title'] = fake.sentence()
+                        document['url'] = fake.url()
+                        documents.append(document)
+                    topic['documents'] = documents
+                    loc_topics.append(topic)
+                lang_topics[loc] = loc_topics
+            langs[lang] = lang_topics
+        topics['languages'] = langs
+        day_data.append(topics)
+    with open('topics/timeline.json', 'w+') as f:
+        json.dump(day_data, f, indent=4)
 
 if __name__ == "__main__":
     generate_vocab()


### PR DESCRIPTION
This adds some mock data to represent the topics page. Here is the basic breakdown of the data organization:

date
---- languages
-------- locales
------------ topic name
------------ phrases
---------------- text
---------------- score
------------ documents
---------------- title
---------------- url

In other words, each date in the timeline contains records for each existing language/locale combination (which presumably the user would be able to filter from the UI) which contains each discovered topic and the associated phrases and documents.